### PR TITLE
'unescape' option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,8 @@ module.exports = function (grunt) {
                     {src: ['test/fixtures/index.html'], dest: 'tmp/custom-append.html'},
                     {src: ['test/fixtures/index.html'], dest: 'tmp/custom-before.html'},
                     {src: ['test/fixtures/index.html'], dest: 'tmp/custom-after.html'},
-                    {src: ['test/fixtures/no-munging-attribute-names.html'], dest: 'tmp/no-munging-attribute-names.html'},
+                    {src: ['test/fixtures/index_unescape.html'], dest: 'tmp/custom-unescape.html'},
+                    {src: ['test/fixtures/no-munging-attribute-names.html'], dest: 'tmp/no-munging-attribute-names.html'}
                 ]
             }
         },
@@ -102,6 +103,25 @@ module.exports = function (grunt) {
                 files: {
                     'tmp/custom-after.html': [
                         'test/fixtures/templates/template1.html',
+                        'test/fixtures/templates/template2.html'
+                    ]
+                }
+            },
+            custom_unescape: {
+                options: {
+                    base: 'test/fixtures',
+                    prefix: '/',
+                    selector: '#templates',
+                    method: 'append',
+                    unescape:{
+                      "&lt;": "<",
+                      "&gt;": ">",
+                      "&apos;": "'",
+                      "&amp;": "&",
+                    }
+                },
+                files: {
+                    'tmp/custom-unescape.html': [
                         'test/fixtures/templates/template2.html'
                     ]
                 }

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -28,14 +28,7 @@ module.exports = function (grunt) {
           var unescaped_html = raw_html;
           // Generating RegExp from 'option.unescape' keys
           var _generateRegexp = function(chars){
-            var ribbon = "";
-            chars.forEach(function(item, index){
-              ribbon += item;
-              if(index !== chars.length - 1){
-                ribbon += "|";
-              }
-            });
-            return new RegExp("(" + ribbon + ")", "g");
+            return new RegExp("(" + chars.join("|") + ")", "g");
           };
           // Get substitution character
           var _fitCharacter = function(match){

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -51,12 +51,13 @@ module.exports = function (grunt) {
             method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
             var html = $.html();
             if(options.unescape){
-              var unescape_regexp = /(&lt;|&gt;|&apos;)/g;
+              var unescape_regexp = /(&lt;|&gt;|&apos;|&amp;)/g;
               var match_cases = {
                 "&lt;": "<",
                 "&gt;": ">",
-                "&apos;": "'"
-              }
+                "&apos;": "'",
+                "&amp;": "&"
+              };
               var _getUnescapedChar = function(match){
                 return match_cases[match];
               };

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -42,9 +42,9 @@ module.exports = function (grunt) {
             return options.unescape[match];
           };
           if(match_keys.length > 0){
-            var pattern = _generateRegexp(match_keys)
-            unescaped_html = raw_html.replace(pattern, _fitCharacter)
-          };
+            var pattern = _generateRegexp(match_keys);
+            unescaped_html = raw_html.replace(pattern, _fitCharacter);
+          }
           return unescaped_html;
         };
 

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -18,7 +18,8 @@ module.exports = function (grunt) {
             base: process.cwd(),
             prefix: '',
             selector: 'body',
-            method: 'prepend'
+            method: 'prepend',
+            unescape: false
         });
 
         // Iterate over all specified file groups.
@@ -48,8 +49,20 @@ module.exports = function (grunt) {
             var $elem = $(options.selector);
             var method = $elem[options.method] || $elem.prepend;
             method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
-
-            grunt.file.write(f.dest, $.html());
+            var html = $.html();
+            if(options.unescape){
+              var unescape_regexp = /(&lt;|&gt;|&apos;)/g;
+              var match_cases = {
+                "&lt;": "<",
+                "&gt;": ">",
+                "&apos;": "'"
+              }
+              var _getUnescapedChar = function(match){
+                return match_cases[match];
+              };
+              html = $.html().replace(unescape_regexp, _getUnescapedChar);
+            }
+            grunt.file.write(f.dest, html);
 
             grunt.log.writeln('Templates inserted into "' + f.dest + '".');
         });

--- a/test/expected/custom-unescape
+++ b/test/expected/custom-unescape
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" href="/styles/9b19ac3c.main.css">
+        <script src="/scripts/vendor/0e15c528.modernizr.js"></script>
+    </head>
+    <body ng-app="boots-app">
+        <!--[if lt IE 7]>
+        <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
+        <![endif]-->
+
+        <div id="templates">
+          <input type="hidden" name="tes_input" ng-init="ang_model = '<?php echo $test_var; ?>'">
+
+
+<!-- Begin Templates -->
+<script type="text/ng-template" id="/templates/template2.html">
+<div>
+    <h1>Template 2</h1>
+</div>
+</script>
+<!-- End Templates -->
+
+</div>
+
+        <!--[if lt IE 9]>
+        <script src="/components/es5-shim/es5-shim.js"></script>
+        <script src="/components/json3/lib/json3.min.js"></script>
+        <![endif]-->
+
+        <!-- Add your site or application content here -->
+        <div ng-view=""></div>
+
+        <script src="/scripts/385c0075.main.js"></script>
+
+        <script src="/assets/0.1.23/dist/boots.min.js"></script>
+
+        <script src="/scripts/3824d063.templates.js"></script>
+
+        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <script>
+            var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+                g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+                s.parentNode.insertBefore(g,s)}(document,'script'));
+        </script>
+    </body>
+</html>

--- a/test/fixtures/index_unescape.html
+++ b/test/fixtures/index_unescape.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" href="/styles/9b19ac3c.main.css">
+        <script src="/scripts/vendor/0e15c528.modernizr.js"></script>
+    </head>
+    <body ng-app="boots-app">
+        <!--[if lt IE 7]>
+        <p class="chromeframe">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> or <a href="http://www.google.com/chromeframe/?redirect=true">activate Google Chrome Frame</a> to improve your experience.</p>
+        <![endif]-->
+
+        <div id="templates">
+          <input type="hidden" name="tes_input" ng-init="ang_model = '<?php echo $test_var; ?>'">
+        </div>
+
+        <!--[if lt IE 9]>
+        <script src="/components/es5-shim/es5-shim.js"></script>
+        <script src="/components/json3/lib/json3.min.js"></script>
+        <![endif]-->
+
+        <!-- Add your site or application content here -->
+        <div ng-view></div>
+
+        <script src="/scripts/385c0075.main.js"></script>
+
+        <script src="/assets/0.1.23/dist/boots.min.js"></script>
+
+        <script src="/scripts/3824d063.templates.js"></script>
+
+        <!-- Google Analytics: change UA-XXXXX-X to be your site's ID. -->
+        <script>
+            var _gaq=[['_setAccount','UA-XXXXX-X'],['_trackPageview']];
+            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+                g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+                s.parentNode.insertBefore(g,s)}(document,'script'));
+        </script>
+    </body>
+</html>

--- a/test/inline_angular_templates_test.js
+++ b/test/inline_angular_templates_test.js
@@ -63,6 +63,14 @@ exports.inline_angular_templates = {
         test.ok(actual.indexOf('data-ng-app')!==-1, 'attribute names should not be munged');
 
         test.done();
-    }
+    },
+    custom_options_unescape: function (test) {
+        test.expect(1);
 
+        var actual = grunt.file.read('tmp/custom-unescape.html');
+        var expected = grunt.file.read('test/expected/custom-unescape');
+        test.equal(stripBlankLines(actual), stripBlankLines(expected));
+
+        test.done();
+    },
 };


### PR DESCRIPTION
Added 'unescape' option to prevent escaping some special characters.
If file has tags like this:

```
<input type="hidden" ng-model="model" ng-init="model='<?php echo $ugly_php_variable; ?>' ">
```

It turns into:

```
<input type="hidden" ng-model="model" ng-init="model=&apos;&lt;?php echo $ugly_php_variable; ?&gt;&apos;''">
```
