### PR TITLE
Minify and strip relative path options

### DIFF
--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
     // Iterate over all specified file groups.
     this.files.forEach(function (f) {
       // Concat specified files.
-      var spacer = options.minify ? '' : '\n\n',
+      var spacer = options.minify ? '\n' : '\n\n',
         src = f.src
           .filter(function (filepath) {
             // Warn on and remove invalid source files (if nonull was set).
@@ -46,8 +46,12 @@ module.exports = function (grunt) {
             }
           })
           .map(function (filepath) {
-            var path = options.onlyPath ? filepath : path.relative(options.base, filepath);
-            var templateUrl = path.join(options.prefix, path).replace(/\\/g, '/');
+          	var templateUrl;
+            if (options.onlyPath) {
+	            templateUrl = options.prefix + filepath;
+            } else {
+	            templateUrl = path.join(options.prefix, path.relative(options.base, filepath)).replace(/\\/g, '/');
+            }
             return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
           }).join(spacer);
       var $ = cheerio.load(grunt.file.read(f.dest), {

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -48,11 +48,15 @@ module.exports = function (grunt) {
           .map(function (filepath) {
           	var templateUrl;
             if (options.onlyPath) {
-	            templateUrl = options.prefix + filepath;
+	            templateUrl = options.prefix + filepath.substring(filepath.indexOf('/') + 1);
             } else {
 	            templateUrl = path.join(options.prefix, path.relative(options.base, filepath)).replace(/\\/g, '/');
             }
-            return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
+            if (options.minify) {
+            	return '<script type="text/ng-template" id="' + templateUrl + '">' + grunt.file.read(filepath) + '</script>';
+            } else {
+            	return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
+            }
           }).join(spacer);
       var $ = cheerio.load(grunt.file.read(f.dest), {
         ignoreWhitespace: false,

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -6,66 +6,74 @@
  * Licensed under the MIT license.
  */
 
-module.exports = function (grunt) {
-    'use strict';
+module.exports = function(grunt) {
+	'use strict';
 
-    var cheerio = require('cheerio'),
-        path = require('path');
+	var cheerio = require('cheerio'),
+		path = require('path');
 
-    grunt.registerMultiTask('inline_angular_templates', 'Inline angular templates into a HTML file', function () {
-        // Merge task-specific and/or target-specific options with these defaults.
-        var options = this.options({
-            base: process.cwd(),
-            prefix: '',
-            selector: 'body',
-            method: 'prepend',
-            unescape: {}
-        });
+	grunt.registerMultiTask('inline_angular_templates', 'Inline angular templates into a HTML file', function() {
+    // Merge task-specific and/or target-specific options with these defaults.
+    var options = this.options({
+			base: process.cwd(),
+			prefix: '',
+			onlyPath: false,
+			selector: 'body',
+			method: 'prepend',
+			minify: false,
+			unescape: {}
+		});
 
-        // Replace characters according to 'unescape' option
-        var unescapeCharacters = function (rawHtml) {
-            var matchKeys = Object.keys(options.unescape);
-            if (matchKeys.length === 0) {
-                return rawHtml;
-            }
-            var pattern = new RegExp('(' + matchKeys.join('|') + ')', 'g');
-            return rawHtml.replace(pattern, function (match) {
-                return options.unescape[match];
-            });
-        };
+		// Replace characters according to 'unescape' option
+		var unescapeCharacters = function(rawHtml) {
+      var matchKeys = Object.keys(options.unescape);
+			if (matchKeys.length === 0) {
+				return rawHtml;
+			}
+			var pattern = new RegExp('(' + matchKeys.join('|') + ')', 'g');
+			return rawHtml.replace(pattern, function(match) {
+        return options.unescape[match];
+			});
+		};
 
-        // Iterate over all specified file groups.
-        this.files.forEach(function (f) {
-            // Concat specified files.
-            var src = f.src
-                .filter(function (filepath) {
-                    // Warn on and remove invalid source files (if nonull was set).
-                    if (!grunt.file.exists(filepath)) {
-                        grunt.log.warn('Source file "' + filepath + '" not found.');
-                        return false;
-                    } else {
-                        return true;
-                    }
-                })
-                .map(function (filepath) {
-                    var templateUrl = path.join(options.prefix, path.relative(options.base, filepath)).replace(/\\/g, '/');
-                    return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
-                }).join('\n\n');
+		// Iterate over all specified file groups.
+		this.files.forEach(function(f) {
+			// Concat specified files.
+      var spacer = options.minify ? '' : '\n\n',
+        src = f.src
+				.filter(function(filepath) {
+					// Warn on and remove invalid source files (if nonull was set).
+					if (!grunt.file.exists(filepath)) {
+						grunt.log.warn('Source file "' + filepath + '" not found.');
+						return false;
+					} else {
+						return true;
+					}
+				})
+				.map(function(filepath) {
+        var path = options.onlyPath ? filepath : path.relative(options.base, filepath);
+        var templateUrl = path.join(options.prefix, path).replace(/\\/g, '/');
+					return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
+				}).join(spacer);
 
-            var $ = cheerio.load(grunt.file.read(f.dest), {
-                ignoreWhitespace: false,
-                xmlMode: false,
-                lowerCaseTags: false
-            });
+			var $ = cheerio.load(grunt.file.read(f.dest), {
+				ignoreWhitespace: false,
+				xmlMode: false,
+				lowerCaseTags: false
+			});
 
-            var $elem = $(options.selector);
-            var method = $elem[options.method] || $elem.prepend;
-            method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
-            var html = unescapeCharacters($.html());
-            grunt.file.write(f.dest, html);
+      var $elem = $(options.selector);
+      var method = $elem[options.method] || $elem.prepend;
+      if (options.minify) {
+				method.call($elem, src);
+			} else {
+				method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
+			}
+			var html = unescapeCharacters($.html());
+			grunt.file.write(f.dest, html);
 
-            grunt.log.writeln('Templates inserted into "' + f.dest + '".');
-        });
-    });
+			grunt.log.writeln('Templates inserted into "' + f.dest + '".');
+		});
+	});
 
 };

--- a/tasks/inline_angular_templates.js
+++ b/tasks/inline_angular_templates.js
@@ -5,75 +5,66 @@
  * Copyright (c) 2013 Luke Bunselmeyer
  * Licensed under the MIT license.
  */
-
-module.exports = function(grunt) {
-	'use strict';
-
-	var cheerio = require('cheerio'),
-		path = require('path');
-
-	grunt.registerMultiTask('inline_angular_templates', 'Inline angular templates into a HTML file', function() {
+module.exports = function (grunt) {
+  'use strict';
+  var cheerio = require('cheerio'),
+    path = require('path');
+  grunt.registerMultiTask('inline_angular_templates', 'Inline angular templates into a HTML file', function () {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-			base: process.cwd(),
-			prefix: '',
-			onlyPath: false,
-			selector: 'body',
-			method: 'prepend',
-			minify: false,
-			unescape: {}
-		});
-
-		// Replace characters according to 'unescape' option
-		var unescapeCharacters = function(rawHtml) {
+      base: process.cwd(),
+      prefix: '',
+      onlyPath: false,
+      selector: 'body',
+      method: 'prepend',
+      minify: false,
+      unescape: {}
+    });
+    // Replace characters according to 'unescape' option
+    var unescapeCharacters = function (rawHtml) {
       var matchKeys = Object.keys(options.unescape);
-			if (matchKeys.length === 0) {
-				return rawHtml;
-			}
-			var pattern = new RegExp('(' + matchKeys.join('|') + ')', 'g');
-			return rawHtml.replace(pattern, function(match) {
+      if (matchKeys.length === 0) {
+        return rawHtml;
+      }
+      var pattern = new RegExp('(' + matchKeys.join('|') + ')', 'g');
+      return rawHtml.replace(pattern, function (match) {
         return options.unescape[match];
-			});
-		};
-
-		// Iterate over all specified file groups.
-		this.files.forEach(function(f) {
-			// Concat specified files.
+      });
+    };
+    // Iterate over all specified file groups.
+    this.files.forEach(function (f) {
+      // Concat specified files.
       var spacer = options.minify ? '' : '\n\n',
         src = f.src
-				.filter(function(filepath) {
-					// Warn on and remove invalid source files (if nonull was set).
-					if (!grunt.file.exists(filepath)) {
-						grunt.log.warn('Source file "' + filepath + '" not found.');
-						return false;
-					} else {
-						return true;
-					}
-				})
-				.map(function(filepath) {
-        var path = options.onlyPath ? filepath : path.relative(options.base, filepath);
-        var templateUrl = path.join(options.prefix, path).replace(/\\/g, '/');
-					return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
-				}).join(spacer);
-
-			var $ = cheerio.load(grunt.file.read(f.dest), {
-				ignoreWhitespace: false,
-				xmlMode: false,
-				lowerCaseTags: false
-			});
-
+          .filter(function (filepath) {
+            // Warn on and remove invalid source files (if nonull was set).
+            if (!grunt.file.exists(filepath)) {
+              grunt.log.warn('Source file "' + filepath + '" not found.');
+              return false;
+            } else {
+              return true;
+            }
+          })
+          .map(function (filepath) {
+            var path = options.onlyPath ? filepath : path.relative(options.base, filepath);
+            var templateUrl = path.join(options.prefix, path).replace(/\\/g, '/');
+            return '<script type="text/ng-template" id="' + templateUrl + '">\n' + grunt.file.read(filepath) + '\n</script>';
+          }).join(spacer);
+      var $ = cheerio.load(grunt.file.read(f.dest), {
+        ignoreWhitespace: false,
+        xmlMode: false,
+        lowerCaseTags: false
+      });
       var $elem = $(options.selector);
       var method = $elem[options.method] || $elem.prepend;
       if (options.minify) {
-				method.call($elem, src);
-			} else {
-				method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
-			}
-			var html = unescapeCharacters($.html());
-			grunt.file.write(f.dest, html);
-
-			grunt.log.writeln('Templates inserted into "' + f.dest + '".');
-		});
-	});
-
+        method.call($elem, src);
+      } else {
+        method.call($elem, '\n\n<!-- Begin Templates -->\n' + src + '\n<!-- End Templates -->\n\n');
+      }
+      var html = unescapeCharacters($.html());
+      grunt.file.write(f.dest, html);
+      grunt.log.writeln('Templates inserted into "' + f.dest + '".');
+    });
+  });
 };


### PR DESCRIPTION
2 new options:
{minify: false(default)} Minify the outputted html, it remoes all spaces
{onlyPath: false(default)} To integrate it with yeoman and the app/, dist/ structure we need the templates name to be the same on local and production code, so strip out the relative path (usually 'dist/'). In this way the template id referenced from a script of our app (templateUrl: 'views/404.html') doesn't ever have to change according to the enviroment.
